### PR TITLE
obsolette inlude removed

### DIFF
--- a/linked_list_queue.c
+++ b/linked_list_queue.c
@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <strings.h>
 #include <string.h>
 #include <assert.h>
 


### PR DESCRIPTION
strings.h is not used in the source code but is absent on windows.